### PR TITLE
windows compile fix

### DIFF
--- a/virvo/virvo/remote/v2/vvremoteserver.h
+++ b/virvo/virvo/remote/v2/vvremoteserver.h
@@ -40,13 +40,13 @@ public:
 
 public:
     // Constructor.
-    VVAPI vvRemoteServer();
+    vvRemoteServer();
 
     // Destructor.
-    VVAPI virtual ~vvRemoteServer();
+    virtual ~vvRemoteServer();
 
     // Resize the frame buffer or ...
-    VVAPI virtual void resize(int w, int h);
+    virtual void resize(int w, int h);
 
     // Sends the image to the client
     virtual void renderImage(ConnectionPointer conn, MessagePointer message,


### PR DESCRIPTION
MSVC is complaining if export macro VVAPI is used for members and in the class definition. Isn't it enough to specify export macro in class definition only?